### PR TITLE
Adding whitespace to event format self.status

### DIFF
--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -603,7 +603,7 @@ class Event(object):
         attributes['tab'] = '\t'
         attributes['bell'] = '\a'
 
-        attributes['status'] = self.status
+        attributes['status'] = self.status+' ' if self.status else ''
         attributes['cancelled'] = 'CANCELLED ' if self.status == 'CANCELLED' else ''
         return format_string.format(**dict(attributes)) + attributes["reset"]
 


### PR DESCRIPTION
Same whitespace handling as for the cancelled status. The {status} field in the event format needs an additional whitespace, if it is present. Otherwise the status is either right next to the next item, or there are two spaces if there is no status.